### PR TITLE
docs: Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=it">Italiano</a>
+        | <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=id">Bahasa Indonesia</a>
+        | <a href="https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=as">অসমীয়া</
+      </div>
+    </div>
+  </details>
+</div>
+
 <p align="center">
   <a href="https://component.gallery">
     <img alt="" src="https://github.com/inbn/component-gallery/raw/main/public/favicon-96x96.png" width="96" />


### PR DESCRIPTION
Added language badges to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian 20 languages.
System will auto-update translation for README and Wiki when this repository updated, and support multiple languages google/bing SEO search, and it's open source project, we can change web or local file mode.

The updated links can be previewed in my forked repository: https://github.com/openaitx-system/component-gallery/tree/Auto_translate_README_and_Wiki

Demo links : 
- [Español](https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=es)
- [简体中文](https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=zh-CN)
- [日本語](https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=ko)
- [Français](https://openaitx.github.io/view.html?user=inbn&project=component-gallery&lang=fr)
..


<img width="1178" height="537" alt="Image" src="https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962  " />

If this doesn't align with your expectations, feel free to close this PR. Thanks for your time! 🙌
